### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/examples/networks.rs
+++ b/examples/networks.rs
@@ -7,7 +7,7 @@ fn main() {
     let docker = Docker::connect_with_defaults().unwrap();
     for network in docker.list_networks(ListNetworkFilters::default()).unwrap() {
         println!(
-            "{:20.12}{:25.}{:10.}{:8.}",
+            "{:20.12}{:25}{:10}{:8}",
             network.Id, network.Name, network.Driver, network.Scope
         );
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.